### PR TITLE
Detect tracked backpack currencies independent of default UI frame

### DIFF
--- a/Bagnon_Currencies.toc
+++ b/Bagnon_Currencies.toc
@@ -1,7 +1,7 @@
 ## Title: Bagnon Currencies
 ## Notes: Makes currencies that is checked in the currency-tab visible in the Bagnon-panels.
-## Author: Spillmaker@Github, semecan@Github
-## Interface: 90001
+## Author: Spillmaker@Github, syndenbock@Github
+## Interface: 90002
 ## Version: 1.1.0
 ## OptionalDeps: Bagnon
 ## BuildName: Bagnon_Currencies


### PR DESCRIPTION
This commit will detect when the player changes the tracked currencies by hooking the WoW API function.
This makes the detection work with addons that replace the default tracking window and/or include a different method for changing tracked currencies.